### PR TITLE
Fix autoClose not being passed to reader

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function fromFd(fd, options, callback) {
   if (callback == null) callback = defaultCallback;
   fs.fstat(fd, function(err, stats) {
     if (err) return callback(err);
-    var reader = fd_slicer.createFromFd(fd, {autoClose: true});
+    var reader = fd_slicer.createFromFd(fd, {autoClose: options.autoClose});
     fromRandomAccessReader(reader, stats.size, options, callback);
   });
 }


### PR DESCRIPTION
This fixes the `autoClose` option not being passed on to
the `fd_slicer`, which was previously always `true` and would
cause file descriptors to be closed when it wasn't intended,
leading to EBADF errors from streams after all file entries were read.