### PR TITLE
Allow decompress option for non-deflate compressed entries

### DIFF
--- a/index.js
+++ b/index.js
@@ -452,7 +452,7 @@ ZipFile.prototype.openReadStream = function(entry, options, callback) {
       }
     }
     if (options.decompress != null) {
-      if (!entry.isCompressed()) {
+      if (entry.compressionMethod === 0) {
         throw new Error("options.decompress can only be specified for compressed entries");
       }
       if (!(options.decompress === false || options.decompress === true)) {
@@ -520,8 +520,10 @@ ZipFile.prototype.openReadStream = function(entry, options, callback) {
       } else if (entry.compressionMethod === 8) {
         // 8 - The file is Deflated
         decompress = options.decompress != null ? options.decompress : true;
-      } else {
+      } else if (options.decompress == null || options.decompress) {
         return callback(new Error("unsupported compression method: " + entry.compressionMethod));
+      } else {
+        decompress = false;
       }
       var fileDataStart = localFileHeaderEnd;
       var fileDataEnd = fileDataStart + entry.compressedSize;


### PR DESCRIPTION
PR for #80.

Currently it is not possible to extract the raw compressed data for entries compressed with a method other than 8 (Deflate).

If you try to open a read stream for an entry compressed with e.g. Deflate64:

* with option `decompress: false`, you get error "options.decompress can only be specified for compressed entries"
* with no `decompress` option, you get error "unsupported compression method: 9"

This PR alters the treatment of the `decompress` option in `.openReadStream()` so you can pass option `decompress: false` and get a stream of the compressed data.

Ideally, I think it'd be better to implement this by altering `entry.isCompressed()` to use `entry.compressionMethod !== 0`. But `isCompressed()` is part of the public API, so that would be a semver-major change. This PR as it stands would (I think) not.