### PR TITLE
Read full central directory at once

### DIFF
--- a/index.js
+++ b/index.js
@@ -314,7 +314,7 @@ ZipFile.prototype._readEntry = function() {
   if (entry.generalPurposeBitFlag & 0x40) return emitErrorAndAutoClose(self, new Error("strong encryption is not supported"));
 
   // fixed-length entry has been read
-  self.readEntryCursor += 46;
+  self.readEntryCursor += buffer.length;
 
   // Read variable-length entry fields (fileNameLength + extraFieldLength + fileCommentLength bytes)
   buffer = self.centralDirectoryBuffer.slice(self.readEntryCursor, self.readEntryCursor + entry.fileNameLength + entry.extraFieldLength + entry.fileCommentLength);
@@ -349,6 +349,10 @@ ZipFile.prototype._readEntry = function() {
     : buffer.slice(fileCommentStart, fileCommentStart + entry.fileCommentLength);
   // compatibility hack for https://github.com/thejoshwolfe/yauzl/issues/47
   entry.comment = entry.fileComment;
+
+  // variable-length entry fields read; update the cursor
+  self.readEntryCursor += buffer.length;
+  self.entriesRead += 1;
 
   if (entry.uncompressedSize === 0xffffffff ||
     entry.compressedSize === 0xffffffff ||
@@ -423,10 +427,6 @@ ZipFile.prototype._readEntry = function() {
       }
     }
   }
-
-  // variable-length entry fields read; update the cursor
-  self.readEntryCursor += entry.fileNameLength + entry.extraFieldLength + entry.fileCommentLength;
-  self.entriesRead += 1;
 
   // validate file size
   if (self.validateEntrySizes && entry.compressionMethod === 0) {

--- a/index.js
+++ b/index.js
@@ -272,9 +272,9 @@ ZipFile.prototype._readEntry = function() {
   if (self.emittedError) return;
 
   var entry = new Entry();
-  var buffer = self.centralDirectoryBuffer.slice(self.readEntryCursor, self.readEntryCursor + 46);
 
   // Read fixed-length entry fields (46 bytes)
+  var buffer = self.centralDirectoryBuffer.slice(self.readEntryCursor, self.readEntryCursor + 46);
 
   // 0 - Central directory file header signature
   var signature = buffer.readUInt32LE(0);


### PR DESCRIPTION
This replaces multiple (2 x entry count) small reads with a single read of the full central directory and eliminates many intermediate `Buffer` allocations and copies in the process, which were resulting in increased time spent reading entries.

With a reasonably-large ZIP archive (1360 entries) in a CPU-constrained environment (AWS Lambda function w/ 128MB allocated), the initial entry read was taking several seconds. Reading and copying data into the individual `Buffer`s that `_readEntry` reads from was taking up to 15ms for each, summing up to multiple seconds for 1000+ entries.

This PR switches things up to read the full central directory at once and uses `readEntryCursor` to track offsets within a single buffer (~80kb for the central directory above). The time needed to read all entries drops to below 50ms in total.