### PR TITLE
Avoid overriding endpointStream.destroy and instead override _destroy so that errors correctly bubble up

### DIFF
--- a/index.js
+++ b/index.js
@@ -564,12 +564,13 @@ ZipFile.prototype.openReadStream = function(entry, options, callback) {
           endpointStream = inflateFilter;
         }
         // this is part of yauzl's API, so implement this function on the client-visible stream
-        endpointStream.destroy = function() {
+        endpointStream._destroy = function(err, cb) {
           destroyed = true;
           if (inflateFilter !== endpointStream) inflateFilter.unpipe(endpointStream);
           readStream.unpipe(inflateFilter);
           // TODO: the inflateFilter may cause a memory leak. see Issue #27.
           readStream.destroy();
+          cb(err);
         };
       }
       callback(null, endpointStream);


### PR DESCRIPTION
Avoided overriding endpointStream.destroy and instead override _destroy as recommended in the stream doc.

https://nodejs.org/api/stream.html#writabledestroyerror

```
Implementors should not override this method, but instead implement [writable._destroy()](https://nodejs.org/api/stream.html#writable_destroyerr-callback).
```

With this change, I was able to capture entry size validation errors, which I could not without the change.