### PR TITLE
Export file data offset in Entry object

### DIFF
--- a/index.js
+++ b/index.js
@@ -288,6 +288,8 @@ ZipFile.prototype._readEntry = function() {
     // 42 - Relative offset of local file header
     entry.relativeOffsetOfLocalHeader = buffer.readUInt32LE(42);
 
+    entry.relativeOffsetOfFileData = null;
+
     if (entry.generalPurposeBitFlag & 0x40) return emitErrorAndAutoClose(self, new Error("strong encryption is not supported"));
 
     self.readEntryCursor += 46;
@@ -513,6 +515,8 @@ ZipFile.prototype.openReadStream = function(entry, options, callback) {
       // 30 - File name
       // 30+n - Extra field
       var localFileHeaderEnd = entry.relativeOffsetOfLocalHeader + buffer.length + fileNameLength + extraFieldLength;
+      entry.relativeOffsetOfFileData = localFileHeaderEnd;
+
       var decompress;
       if (entry.compressionMethod === 0) {
         // 0 - The file is stored (no compression)


### PR DESCRIPTION
It can be useful for user to be able to obtain the location of the file data for an entry in the ZIP file. For example, if a ZIP file is stored in cloud storage, and you wish to download just a single file from that ZIP, knowing the offset of the data in the ZIP allows extracting that single file with only 1 HTTP request.

This PR adds a property `relativeOffsetOfFileData` to `Entry`s for this purpose. The property is initially `null`, but is populated when `openReadStream()` is called with the entry.