### PR TITLE
add some low level APIs 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /coverage
 /node_modules
+/test/.tmp

--- a/README.md
+++ b/README.md
@@ -763,6 +763,7 @@ This library makes no attempt to interpret the Language Encoding Flag.
      Added fields to `Class: Entry`: `fileNameRaw`, `extraFieldRaw`, `fileCommentRaw`.
    * Added `examples/compareCentralAndLocalHeaders.js` that demonstrate many of these low level APIs.
    * Noted dropped support of node versions before 12 in the `"engines"` field of `package.json`.
+   * Fixed a crash when calling `openReadStream()` with an explicitly `null` options parameter (as opposed to omitted).
  * 3.0.0
    * BREAKING CHANGE: implementations of [RandomAccessReader](#class-randomaccessreader) that implement a `destroy` method must instead implement `_destroy` in accordance with the node standard https://nodejs.org/api/stream.html#writable_destroyerr-callback (note the error and callback parameters). If you continue to override `destory` instead, some error handling may be subtly broken. Additionally, this is required for async iterators to work correctly in some versions of node. [issue #110](https://github.com/thejoshwolfe/yauzl/issues/110)
    * BREAKING CHANGE: Drop support for node versions older than 12.

--- a/README.md
+++ b/README.md
@@ -304,6 +304,10 @@ must provide readable streams that implement a `._destroy()` method according to
 https://nodejs.org/api/stream.html#writable_destroyerr-callback (see `randomAccessReader._readStreamForRange()`)
 in order for calls to `readStream.destroy()` to work in this context.
 
+#### readLocalFileHeader(entry, [options], callback)
+
+TBD
+
 #### close()
 
 Causes all future calls to `openReadStream()` to fail,
@@ -359,12 +363,17 @@ These fields are of type `Number`:
  * `crc32`
  * `compressedSize`
  * `uncompressedSize`
- * `fileNameLength` (bytes)
- * `extraFieldLength` (bytes)
- * `fileCommentLength` (bytes)
+ * `fileNameLength` (in bytes)
+ * `extraFieldLength` (in bytes)
+ * `fileCommentLength` (in bytes)
  * `internalFileAttributes`
  * `externalFileAttributes`
  * `relativeOffsetOfLocalHeader`
+
+There are additional fields described below: `fileName`, `extraFields`, `comment`.
+
+The `new Entry()` constructor is available for clients to call, but it's usually not useful.
+The constructor takes no parameters and does nothing; no fields will exist.
 
 #### fileName
 
@@ -441,6 +450,10 @@ return this.compressionMethod === 8;
 ```
 
 See `openReadStream()` for the implications of this value.
+
+### Class: LocalFileHeader
+
+TBD
 
 ### Class: RandomAccessReader
 
@@ -631,6 +644,9 @@ This library makes no attempt to interpret the Language Encoding Flag.
 
 ## Change History
 
+ * 3.1.0
+   * Added `readLocalFileHeader()` and `class LocalFileHeader`.
+   * Noted deprecation of node versions before 12 in the `"engines"` field of `package.json`.
  * 3.0.0
    * BREAKING CHANGE: implementations of [RandomAccessReader](#class-randomaccessreader) that implement a `destroy` method must instead implement `_destroy` in accordance with the node standard https://nodejs.org/api/stream.html#writable_destroyerr-callback (note the error and callback parameters). If you continue to override `destory` instead, some error handling may be subtly broken. Additionally, this is required for async iterators to work correctly in some versions of node. [issue #110](https://github.com/thejoshwolfe/yauzl/issues/110)
    * BREAKING CHANGE: Drop support for node versions older than 12.

--- a/README.md
+++ b/README.md
@@ -182,6 +182,18 @@ if (errorMessage != null) throw new Error(errorMessage);
 This function is automatically run for each entry, as long as `decodeStrings` is `true`.
 See `open()`, `strictFileNames`, and `Event: "entry"` for more information.
 
+### parseExtraFields(extraFieldBuffer)
+
+This function is used internally by yauzl to compute [`entry.extraFields`](#extrafields).
+It is exported in case you want to call it on [`localFileHeader.extraField`](#class-localfileheader).
+
+`extraFieldBuffer` is a `Buffer`, such as `localFileHeader.extraField`.
+Returns an `Array` with each item in the form `{id: id, data: data}`,
+where `id` is a `Number` and `data` is a `Buffer`.
+Throws an `Error` if the data encodes an item with a size that exceeds the bounds of the buffer.
+
+You may want to surround calls to this function with `try { ... } catch (err) { ... }` to handle the error.
+
 ### Class: ZipFile
 
 The constructor for the class is not part of the public API.
@@ -437,7 +449,7 @@ Furthermore, no automatic file name validation is performed for this file name.
 
 #### extraFields
 
-`Array` with each entry in the form `{id: id, data: data}`,
+`Array` with each item in the form `{id: id, data: data}`,
 where `id` is a `Number` and `data` is a `Buffer`.
 
 This library looks for and reads the ZIP64 Extended Information Extra Field (0x0001)
@@ -520,6 +532,7 @@ See the zipfile spec for what these fields mean.
 
 Note that unlike `Class: Entry`, the `fileName` and `extraField` are completely unprocessed.
 This notably lacks Unicode and ZIP64 handling as well as any kind of safety validation on the file name.
+See also [`parseExtraFields()`](#parseextrafields-extrafieldbuffer).
 
 Also note that if your object is missing some of these fields,
 make sure to read the docs on the `minimal` option in `readLocalFileHeader()`.

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ This is a low-level function available for advanced use cases. You probably want
 
 The intended use case for this function is calling `readEntry()` and `readLocalFileHeader()` with `{minimal: true}` first,
 and then opening the read stream at a later time, possibly after closing and reopening the entire zipfile,
-possible even in a different process.
+possibly even in a different process.
 The parameters are all integers and booleans, which are friendly to serialization.
 
 * `fileDataStart` - from `localFileHeader.fileDataStart`
@@ -344,14 +344,14 @@ The parameters are all integers and booleans, which are friendly to serializatio
 * `relativeStart` - the resolved value of `options.start` from `openReadStream()`. Must be a non-negative integer, not `null`. Typically `0` to start at the beginning of the data.
 * `relativeEnd` - the resolved value of `options.end` from `openReadStream()`. Must be a non-negative integer, not `null`. Typically `entry.compressedSize` to include all the data.
 * `decompress` - boolean indicating whether the data should be piped through a zlib inflate stream.
-* `uncompressedSize` - from `entry.uncompressedSize`. Only used when `validateEntrySizes` is `true`. If `validateEntrySizes` is `false`, this value is ignored, but must not be omitted from the arguments.
-* `callback` - receives `(err, readStream)`, the same as `openReadStream()`
+* `uncompressedSize` - from `entry.uncompressedSize`. Only used when `validateEntrySizes` is `true`. If `validateEntrySizes` is `false`, this value is ignored, but must still be present, not omitted, in the arguments; you have to give it some value, even if it's `null`.
+* `callback` - receives `(err, readStream)`, the same as for `openReadStream()`
 
 This low-level function does not read any metadata from the underlying storage before opening the read stream.
 This is both a performance feature and a safety hazard.
 None of the integer parameters are bounds checked.
-None of the validation from `openReadStream()` with respect to compression and encryption is done here.
-The bounds checks from `validateEntrySizes` are still done, because that requires processing the stream data.
+None of the validation from `openReadStream()` with respect to compression and encryption is done here either.
+Only the bounds checks from `validateEntrySizes` are done, because that is part of processing the stream data.
 
 #### close()
 
@@ -498,7 +498,7 @@ See `openReadStream()` for the implications of this value.
 
 ### Class: LocalFileHeader
 
-This is trivial class that has no methods and only the following properties.
+This is a trivial class that has no methods and only the following properties.
 The constructor is available to call, but it doesn't do anything.
 See `readLocalFileHeader()`.
 
@@ -522,7 +522,7 @@ Note that unlike `Class: Entry`, the `fileName` and `extraField` are completely 
 This notably lacks Unicode and ZIP64 handling as well as any kind of safety validation on the file name.
 
 Also note that if your object is missing some of these fields,
-you should read the docs on the `minimal` option in `readLocalFileHeader()`.
+make sure to read the docs on the `minimal` option in `readLocalFileHeader()`.
 
 ### Class: RandomAccessReader
 

--- a/README.md
+++ b/README.md
@@ -452,11 +452,10 @@ These fields are of type `Number`:
 These fields are of type `Buffer`, and represent variable-length bytes before being processed:
  * `fileNameRaw`
  * `extraFieldRaw`
- * `commentRaw`
+ * `fileCommentRaw`
 
-There are additional fields described below: `fileName`, `extraFields`, `comment`.
-These are the `*Raw` fields above after going through some processing, such as UTF-8 decoding.
-See their own sections below.
+There are additional fields described below: `fileName`, `extraFields`, `fileComment`.
+These are the processed versions of the `*Raw` fields listed above. See their own sections below.
 (Note the inconsistency in pluralization of "field" vs "fields" in `extraField`, `extraFields`, and `extraFieldRaw`.
 Sorry about that.)
 
@@ -761,7 +760,8 @@ This library makes no attempt to interpret the Language Encoding Flag.
    * Added `readLocalFileHeader()` and `Class: LocalFileHeader`.
    * Added `openReadStreamLowLevel()`.
    * Added `getFileNameLowLevel()` and `parseExtraFields()`.
-     Added fields to `Class: Entry`: `fileNameRaw`, `extraFieldRaw`, `commentRaw`.
+     Added fields to `Class: Entry`: `fileNameRaw`, `extraFieldRaw`, `fileCommentRaw`.
+   * Added `examples/compareCentralAndLocalHeaders.js` that demonstrate many of these low level APIs.
    * Noted dropped support of node versions before 12 in the `"engines"` field of `package.json`.
  * 3.0.0
    * BREAKING CHANGE: implementations of [RandomAccessReader](#class-randomaccessreader) that implement a `destroy` method must instead implement `_destroy` in accordance with the node standard https://nodejs.org/api/stream.html#writable_destroyerr-callback (note the error and callback parameters). If you continue to override `destory` instead, some error handling may be subtly broken. Additionally, this is required for async iterators to work correctly in some versions of node. [issue #110](https://github.com/thejoshwolfe/yauzl/issues/110)

--- a/examples/compareCentralAndLocalHeaders.js
+++ b/examples/compareCentralAndLocalHeaders.js
@@ -1,0 +1,142 @@
+
+var yauzl = require("../"); // replace with: var yauzl = require("yauzl");
+
+function usage() {
+  console.log(
+    "usage: node compareCentralAndLocalHeaders.js path/to/file.zip\n" +
+    "\n" +
+    "Shows a table comparing the central directory metadata and local\n" +
+    "file headers for each item in a zipfile.\n" +
+    "");
+  process.exit(1);
+}
+
+var zipfilePath = null;
+var detailedExtraFieldBreakdown = true;
+process.argv.slice(2).forEach(function(arg) {
+  if (/^-/.test(arg)) usage();
+  if (zipfilePath != null) usage();
+  zipfilePath = arg;
+});
+if (zipfilePath == null) usage();
+
+yauzl.open(zipfilePath, {lazyEntries: true, decodeStrings: false}, function(err, zipfile) {
+  if (err) throw err;
+  zipfile.on("error", function(err) {
+    throw err;
+  });
+  zipfile.readEntry();
+  zipfile.on("entry", function(entry) {
+    zipfile.readLocalFileHeader(entry, function(err, localFileHeader) {
+      if (err) throw err;
+      compare(entry, localFileHeader);
+      zipfile.readEntry();
+    });
+  });
+})
+
+function compare(entry, localFileHeader) {
+  console.log(yauzl.getFileNameLowLevel(entry.generalPurposeBitFlag, entry.fileNameRaw, entry.extraFields, false));
+
+  // Compare integers
+  var integerFields = [
+    "versionMadeBy",
+    "versionNeededToExtract",
+    "generalPurposeBitFlag",
+    "compressionMethod",
+    "lastModFileTime",
+    "lastModFileDate",
+    "crc32",
+    "compressedSize",
+    "uncompressedSize",
+    "fileNameLength",
+    "extraFieldLength",
+    "fileCommentLength",
+    "internalFileAttributes",
+    "externalFileAttributes",
+    "relativeOffsetOfLocalHeader",
+  ];
+  function formatNumber(numberOrNull) {
+    if (numberOrNull == null) return "-";
+    return "0x" + numberOrNull.toString(16);
+  }
+
+  var rows = [["field", "central", "local", "diff"]];
+  rows.push(...integerFields.map(function(name) {
+    var a = entry[name];
+    var b = localFileHeader[name];
+    var diff = a == null || b == null ? "" :
+      a === b ? "" : "x";
+    return [name, formatNumber(a), formatNumber(b), diff]
+  }));
+
+  var columnWidths = [0, 1, 2, 3].map(function(i) {
+    return Math.max(...rows.map(row => row[i].length));
+  });
+  var formatFunctions = ["padEnd", "padStart", "padStart", "padEnd"];
+
+  console.log("┌" + columnWidths.map(w => "─".repeat(w)).join("┬") + "┐");
+  for (var i = 0; i < rows.length; i++) {
+    console.log("│" + rows[i].map((x, j) => x[formatFunctions[j]](columnWidths[j])).join("│") + "│");
+    if (i === 0) {
+      console.log("├" + columnWidths.map(w => "─".repeat(w)).join("┼") + "┤");
+    }
+  }
+  console.log("└" + columnWidths.map(w => "─".repeat(w)).join("┴") + "┘");
+
+  // Compare variable length data.
+  console.log("central.fileName:", entry.fileNameRaw.toString("hex"));
+  if (entry.fileNameRaw.equals(localFileHeader.fileName)) {
+    console.log("(local matches)");
+  } else {
+    console.log("  local.fileName:", localFileHeader.fileName.toString("hex"));
+  }
+  console.log("central.extraField:", entry.extraFieldRaw.toString("hex"));
+  if (entry.extraFieldRaw.equals(localFileHeader.extraField)) {
+    console.log("(local matches)");
+  } else {
+    console.log("  local.extraField:", localFileHeader.extraField.toString("hex"));
+  }
+
+  if (detailedExtraFieldBreakdown) {
+    var centralExtraFieldMap = extraFieldsToMap(entry.extraFields);
+    var localExtraFieldMap = extraFieldsToMap(yauzl.parseExtraFields(localFileHeader.extraField));
+    for (var key in centralExtraFieldMap) {
+      var centralData = centralExtraFieldMap[key];
+      var localData = localExtraFieldMap[key];
+      delete localExtraFieldMap[key]; // to isolate unhandled keys.
+      console.log("    [" + key + "]central:", centralData.toString("hex"));
+      if (localData != null && centralData.equals(localData)) {
+        console.log("    [" + key + "](local matches)");
+      } else if (localData != null) {
+        console.log("    [" + key + "]  local:", localData.toString("hex"));
+      } else {
+        console.log("    [" + key + "]  local: <missing>");
+      }
+    }
+    // Any keys left here don't match anything.
+    for (var key in localExtraFieldMap) {
+      var localData = localExtraFieldMap[key];
+      console.log("    [" + key + "]central: <missing>");
+      console.log("    [" + key + "]  local:", localData.toString("hex"));
+    }
+  }
+  console.log("central.comment:", entry.fileCommentRaw.toString("hex"));
+
+  console.log("");
+}
+
+function extraFieldsToMap(extraFields) {
+  var map = {};
+  extraFields.forEach(({id, data}) => {
+    var key = "0x" + id.toString(16).padStart(4, "0");
+    var baseKey = key;
+    var i = 1;
+    while (key in map) {
+      key = baseKey + "." + i;
+      i++;
+    }
+    map[key] = data;
+  });
+  return map;
+}

--- a/examples/promises.js
+++ b/examples/promises.js
@@ -10,7 +10,7 @@
 
 let yauzl = require("../"); // replace with: let yauzl = require("yauzl");
 
-let simpleZipBuffer = new Buffer([
+let simpleZipBuffer = Buffer.from([
   80,75,3,4,20,0,8,8,0,0,134,96,146,74,0,0,
   0,0,0,0,0,0,0,0,0,0,5,0,0,0,97,46,116,120,
   116,104,101,108,108,111,10,80,75,7,8,32,

--- a/index.js
+++ b/index.js
@@ -582,46 +582,46 @@ ZipFile.prototype.readLocalFileHeader = function(entry, options, callback) {
 
       if (options.minimal) {
         return callback(null, {fileDataStart: fileDataStart});
-      } else {
-        var localFileHeader = new LocalFileHeader();
-        localFileHeader.fileDataStart = fileDataStart;
-
-        // 4 - Version needed to extract (minimum)
-        localFileHeader.versionNeededToExtract = buffer.readUInt16LE(4);
-        // 6 - General purpose bit flag
-        localFileHeader.generalPurposeBitFlag = buffer.readUInt16LE(6);
-        // 8 - Compression method
-        localFileHeader.compressionMethod = buffer.readUInt16LE(8);
-        // 10 - File last modification time
-        localFileHeader.lastModFileTime = buffer.readUInt16LE(10);
-        // 12 - File last modification date
-        localFileHeader.lastModFileDate = buffer.readUInt16LE(12);
-        // 14 - CRC-32
-        localFileHeader.crc32 = buffer.readUInt32LE(14);
-        // 18 - Compressed size
-        localFileHeader.compressedSize = buffer.readUInt32LE(18);
-        // 22 - Uncompressed size
-        localFileHeader.uncompressedSize = buffer.readUInt32LE(22);
-        // 26 - File name length (n)
-        localFileHeader.fileNameLength = fileNameLength;
-        // 28 - Extra field length (m)
-        localFileHeader.extraFieldLength = extraFieldLength;
-        // 30 - File name
-        // 30+n - Extra field
-
-        buffer = newBuffer(fileNameLength + extraFieldLength);
-        self.reader.ref();
-        readAndAssertNoEof(self.reader, buffer, 0, buffer.length, entry.relativeOffsetOfLocalHeader + 30, function(err) {
-          try {
-            if (err) return callback(err);
-            localFileHeader.fileName = buffer.subarray(0, fileNameLength);
-            localFileHeader.extraField = buffer.subarray(fileNameLength);
-            return callback(null, localFileHeader);
-          } finally {
-            self.reader.unref();
-          }
-        });
       }
+
+      var localFileHeader = new LocalFileHeader();
+      localFileHeader.fileDataStart = fileDataStart;
+
+      // 4 - Version needed to extract (minimum)
+      localFileHeader.versionNeededToExtract = buffer.readUInt16LE(4);
+      // 6 - General purpose bit flag
+      localFileHeader.generalPurposeBitFlag = buffer.readUInt16LE(6);
+      // 8 - Compression method
+      localFileHeader.compressionMethod = buffer.readUInt16LE(8);
+      // 10 - File last modification time
+      localFileHeader.lastModFileTime = buffer.readUInt16LE(10);
+      // 12 - File last modification date
+      localFileHeader.lastModFileDate = buffer.readUInt16LE(12);
+      // 14 - CRC-32
+      localFileHeader.crc32 = buffer.readUInt32LE(14);
+      // 18 - Compressed size
+      localFileHeader.compressedSize = buffer.readUInt32LE(18);
+      // 22 - Uncompressed size
+      localFileHeader.uncompressedSize = buffer.readUInt32LE(22);
+      // 26 - File name length (n)
+      localFileHeader.fileNameLength = fileNameLength;
+      // 28 - Extra field length (m)
+      localFileHeader.extraFieldLength = extraFieldLength;
+      // 30 - File name
+      // 30+n - Extra field
+
+      buffer = newBuffer(fileNameLength + extraFieldLength);
+      self.reader.ref();
+      readAndAssertNoEof(self.reader, buffer, 0, buffer.length, entry.relativeOffsetOfLocalHeader + 30, function(err) {
+        try {
+          if (err) return callback(err);
+          localFileHeader.fileName = buffer.subarray(0, fileNameLength);
+          localFileHeader.extraField = buffer.subarray(fileNameLength);
+          return callback(null, localFileHeader);
+        } finally {
+          self.reader.unref();
+        }
+      });
     } finally {
       self.reader.unref();
     }

--- a/index.js
+++ b/index.js
@@ -402,6 +402,9 @@ ZipFile.prototype.openReadStream = function(entry, options, callback) {
   var relativeEnd = entry.compressedSize;
   if (callback == null) {
     callback = options;
+    options = null;
+  }
+  if (options == null) {
     options = {};
   } else {
     // validate options that the caller has no excuse to get wrong
@@ -519,8 +522,9 @@ ZipFile.prototype.readLocalFileHeader = function(entry, options, callback) {
   var self = this;
   if (callback == null) {
     callback = options;
-    options = {};
+    options = null;
   }
+  if (options == null) options = {};
 
   self.reader.ref();
   var buffer = newBuffer(30);
@@ -754,6 +758,7 @@ RandomAccessReader.prototype.unref = function() {
   }
 };
 RandomAccessReader.prototype.createReadStream = function(options) {
+  if (options == null) options = {};
   var start = options.start;
   var end = options.end;
   if (start === end) {

--- a/index.js
+++ b/index.js
@@ -685,8 +685,7 @@ function parseExtraFields(extraFieldBuffer) {
     var dataStart = i + 4;
     var dataEnd = dataStart + dataSize;
     if (dataEnd > extraFieldBuffer.length) throw new Error("extra field length exceeds extra field buffer size");
-    var dataBuffer = newBuffer(dataSize);
-    extraFieldBuffer.copy(dataBuffer, 0, dataStart, dataEnd);
+    var dataBuffer = extraFieldBuffer.subarray(dataStart, dataEnd);
     extraFields.push({
       id: headerId,
       data: dataBuffer,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,9 @@
       },
       "devDependencies": {
         "bl": "^6.0.11"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "yauzl",
   "version": "3.0.0",
   "description": "yet another unzip library for node",
+  "engines": {
+    "node": ">=12"
+  },
   "main": "index.js",
   "scripts": {
     "test": "node test/test.js"

--- a/test/test.js
+++ b/test/test.js
@@ -96,7 +96,7 @@ listZipFiles([path.join(__dirname, "success"), path.join(__dirname, "wrong-entry
             // Do this asynchronously because it's not critical,
             // and this way it might find race condition bugs with autoclose.
             zipfile.readLocalFileHeader(entry, function(err, localFileHeader) {
-              // This is the one field unique to the local file header.
+              // Just check one of non-minumal fields fields.
               if (localFileHeader.versionNeededToExtract == null) throw new Error(messagePrefix + "local file header missing versionNeededToExtract field");
               // This field is the most mechnically important field.
               if (localFileHeader.fileDataStart == null) throw new Error(messagePrefix + "local file header missing fileDataStart field");

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,7 @@ var fs = require("fs");
 var path = require("path");
 var Pend = require("pend");
 var util = require("util");
+var child_process = require("child_process");
 var Readable = require("stream").Readable;
 var Writable = require("stream").Writable;
 
@@ -92,15 +93,6 @@ listZipFiles([path.join(__dirname, "success"), path.join(__dirname, "wrong-entry
             var timestamp = entry.getLastModDate();
             if (timestamp < earliestTimestamp) throw new Error(messagePrefix + "timestamp too early: " + timestamp);
             if (timestamp > new Date()) throw new Error(messagePrefix + "timestamp in the future: " + timestamp);
-
-            // Do this asynchronously because it's not critical,
-            // and this way it might find race condition bugs with autoclose.
-            zipfile.readLocalFileHeader(entry, function(err, localFileHeader) {
-              // Just check one of non-minumal fields fields.
-              if (localFileHeader.versionNeededToExtract == null) throw new Error(messagePrefix + "local file header missing versionNeededToExtract field");
-              // This field is the most mechnically important field.
-              if (localFileHeader.fileDataStart == null) throw new Error(messagePrefix + "local file header missing fileDataStart field");
-            });
 
             var fileNameKey = fileName.replace(/\/$/, "");
             var expectedContents = expectedArchiveContents[fileNameKey];
@@ -356,6 +348,70 @@ pend.go(zip64.runTest);
 
 // openReadStream with range
 pend.go(rangeTest.runTest);
+
+// Make sure the examples run with crashing.
+pend.go(function(cb) {
+  var examplesDir = path.join(__dirname, "../examples");
+  var zipfiles = listZipFiles([path.join(__dirname, "success")]);
+  var tmpDir = path.join(__dirname, ".tmp");
+  if (typeof fs.rmSync === "function") fs.rmSync(tmpDir, {recursive: true, force: true});
+
+  var parametersToTest = {
+    "compareCentralAndLocalHeaders.js": zipfiles,
+    "dump.js": zipfiles,
+    "promises.js": [null],
+    "unzip.js": zipfiles,
+  };
+  if (JSON.stringify(fs.readdirSync(examplesDir).sort()) !== JSON.stringify(Object.keys(parametersToTest).sort())) throw new Error("unexpected examples/ directory listing");
+  for (var f in parametersToTest) {
+    var args = parametersToTest[f];
+    var script = path.join(examplesDir, f);
+
+    if (f === "unzip.js" && typeof fs.rmSync !== "function") {
+      console.log("WARNING: skipping examples/unzip.js tests for node <14");
+      continue;
+    }
+
+    args.forEach(function(arg) {
+      var args = [path.resolve(script)];
+      var options = {
+        stdio: ["ignore", "ignore", "inherit"],
+        timeout: 10_000,
+      };
+      var testId;
+      if (arg != null) {
+        args.push(path.resolve(arg));
+        testId = `examples/${f} ${path.basename(arg)}: `;
+      } else {
+        testId = `examples/${f}: `;
+      }
+
+      // Handle special cases.
+      if (f === "dump.js" && /traditional-encryption/.exec(path.basename(arg))) {
+        args.push("--no-contents");
+      }
+      if (f === "unzip.js") {
+        if (/traditional-encryption/.exec(path.basename(arg))) return; // Can't do these.
+        // Quaranetine this in a temp directory.
+        fs.mkdirSync(tmpDir);
+        options.cwd = tmpDir;
+      }
+
+      process.stdout.write(testId);
+      var {status, error} = child_process.spawnSync("node", args, options);
+      if (status) error = new Error("child process return exit code " + status);
+      if (error) throw error;
+
+      if (f === "unzip.js") {
+        // Quaranetine this in a temp directory.
+        fs.rmSync(tmpDir, {recursive: true, force: true});
+      }
+
+      process.stdout.write("pass\n");
+    });
+  }
+  cb();
+});
 
 var done = false;
 pend.wait(function() {

--- a/test/zip64.js
+++ b/test/zip64.js
@@ -87,7 +87,7 @@ function newLargeBinContentsProducer() {
         readStream.push(null);
         return;
       }
-      var bufferSize = Math.min(0x10000, largeBinLength - byteCount);
+      var bufferSize = Math.min(0x800000, largeBinLength - byteCount);
       var buffer = Buffer.allocUnsafe(bufferSize);
       for (var i = 0; i < bufferSize; i += 4) {
         var n = ((prev0 + prev1) & 0xffffffff) >>> 0;


### PR DESCRIPTION
   * Added `readLocalFileHeader()` and `Class: LocalFileHeader`.
   * Added `openReadStreamLowLevel()`.
   * Added `getFileNameLowLevel()` and `parseExtraFields()`. Added fields to `Class: Entry`: `fileNameRaw`, `extraFieldRaw`, `fileCommentRaw`.
   * Added `examples/compareCentralAndLocalHeaders.js` that demonstrate many of these low level APIs.
   * Noted dropped support of node versions before 12 in the `"engines"` field of `package.json`.
   * Fixed a crash when calling `openReadStream()` with an explicitly `null` options parameter (as opposed to omitted).

Here's some of the readme additions copied into this PR for convenience:


### getFileNameLowLevel(generalPurposeBitFlag, fileNameBuffer, extraFields, strictFileNames)

If you are setting `decodeStrings` to `false`, then this function can be used to decode the file name yourself.
This function is effectively used internally by yauzl to populate the `entry.fileName` field when `decodeStrings` is `true`.

WARNING: This method of getting the file name bypasses the security checks in [`validateFileName()`](#validatefilename-filename).
You should call that function yourself to be sure to guard against malicious file paths.

`generalPurposeBitFlag` can be found on an [`Entry`](#class-entry) or [`LocalFileHeader`](#class-localfileheader).
Only General Purpose Bit 11 is used, and only when an Info-ZIP Unicode Path Extra Field cannot be found in `extraFields`.

`fileNameBuffer` is a `Buffer` representing the file name field of the entry.
This is `entry.fileNameRaw` or `localFileHeader.fileName`.

`extraFields` is the parsed extra fields array from `entry.extraFields` or `parseExtraFields()`.

`strictFileNames` is a boolean, the same as the option of the same name in `open()`.
When `false`, backslash characters (`\`) will be replaced with forward slash characters (`/`).
This function always returns a string, although it may not be a valid file name.
See `validateFileName()`.

### parseExtraFields(extraFieldBuffer)

This function is used internally by yauzl to compute [`entry.extraFields`](#extrafields).
It is exported in case you want to call it on [`localFileHeader.extraField`](#class-localfileheader).

`extraFieldBuffer` is a `Buffer`, such as `localFileHeader.extraField`.
Returns an `Array` with each item in the form `{id: id, data: data}`,
where `id` is a `Number` and `data` is a `Buffer`.
Throws an `Error` if the data encodes an item with a size that exceeds the bounds of the buffer.

You may want to surround calls to this function with `try { ... } catch (err) { ... }` to handle the error.

#### readLocalFileHeader(entry, [options], callback)

This is a low-level function you probably don't need to call.
The intended use case is either preparing to call `openReadStreamLowLevel()`
or simply examining the content of the local file header out of curiosity or for debugging zip file structure issues.

`entry` is an entry obtained from `Event: "entry"`.
An `entry` in this library is a file's metadata from a Central Directory Header,
and this function gives the corresponding redundant data in a Local File Header.

`options` may be omitted or `null`, and has the following defaults:

```js
{
  minimal: false,
}
```

If `minimal` is `false` (or omitted or `null`), the callback receives a full `LocalFileHeader`.
If `minimal` is `true`, the callback receives an object with a single property and no prototype `{fileDataStart: fileDataStart}`.
For typical zipfile reading usecases, this field is the only one you need,
and yauzl internally effectively uses the `{minimal: true}` option as part of `openReadStream()`.

The `callback` receives `(err, localFileHeaderOrAnObjectWithJustOneFieldDependingOnTheMinimalOption)`,
where the type of the second parameter is described in the above discussion of the `minimal` option.

#### openReadStreamLowLevel(fileDataStart, compressedSize, relativeStart, relativeEnd, decompress, uncompressedSize, callback)

This is a low-level function available for advanced use cases. You probably want `openReadStream()` instead.

The intended use case for this function is calling `readEntry()` and `readLocalFileHeader()` with `{minimal: true}` first,
and then opening the read stream at a later time, possibly after closing and reopening the entire zipfile,
possibly even in a different process.
The parameters are all integers and booleans, which are friendly to serialization.

* `fileDataStart` - from `localFileHeader.fileDataStart`
* `compressedSize` - from `entry.compressedSize`
* `relativeStart` - the resolved value of `options.start` from `openReadStream()`. Must be a non-negative integer, not `null`. Typically `0` to start at the beginning of the data.
* `relativeEnd` - the resolved value of `options.end` from `openReadStream()`. Must be a non-negative integer, not `null`. Typically `entry.compressedSize` to include all the data.
* `decompress` - boolean indicating whether the data should be piped through a zlib inflate stream.
* `uncompressedSize` - from `entry.uncompressedSize`. Only used when `validateEntrySizes` is `true`. If `validateEntrySizes` is `false`, this value is ignored, but must still be present, not omitted, in the arguments; you have to give it some value, even if it's `null`.
* `callback` - receives `(err, readStream)`, the same as for `openReadStream()`

This low-level function does not read any metadata from the underlying storage before opening the read stream.
This is both a performance feature and a safety hazard.
None of the integer parameters are bounds checked.
None of the validation from `openReadStream()` with respect to compression and encryption is done here either.
Only the bounds checks from `validateEntrySizes` are done, because that is part of processing the stream data.

### Class: LocalFileHeader

This is a trivial class that has no methods and only the following properties.
The constructor is available to call, but it doesn't do anything.
See `readLocalFileHeader()`.

See the zipfile spec for what these fields mean.

 * `fileDataStart` - `Number`: inferred from `fileNameLength`, `extraFieldLength`, and this struct's position in the zipfile.
 * `versionNeededToExtract` - `Number`
 * `generalPurposeBitFlag` - `Number`
 * `compressionMethod` - `Number`
 * `lastModFileTime` - `Number`
 * `lastModFileDate` - `Number`
 * `crc32` - `Number`
 * `compressedSize` - `Number`
 * `uncompressedSize` - `Number`
 * `fileNameLength` - `Number`
 * `extraFieldLength` - `Number`
 * `fileName` - `Buffer`
 * `extraField` - `Buffer`

Note that unlike `Class: Entry`, the `fileName` and `extraField` are completely unprocessed.
This notably lacks Unicode and ZIP64 handling as well as any kind of safety validation on the file name.
See also [`parseExtraFields()`](#parseextrafields-extrafieldbuffer).

Also note that if your object is missing some of these fields,
make sure to read the docs on the `minimal` option in `readLocalFileHeader()`.

