### PR TITLE
Fix crash when using `fromBuffer()` to read corrupt zip files that specify out of bounds file offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,3 +836,11 @@ The zip file specification has several ambiguities inherent in its design. Yikes
    * Fix bug with using `iconv`.
  * 2.0.0
    * Initial release.
+
+## Development
+
+One of the trickiest things in development is crafting test cases located in `test/{success,failure}/`.
+These are zip files that have been specifically generated or design to test certain conditions in this library.
+I recommend using [hexdump-zip](https://github.com/thejoshwolfe/hexdump-zip) to examine the structure of a zipfile.
+
+For making new error cases, I typically start by copying `test/success/linux-info-zip.zip`, and then editing a few bytes with a hex editor.

--- a/README.md
+++ b/README.md
@@ -763,6 +763,9 @@ The zip file specification has several ambiguities inherent in its design. Yikes
 
 ## Change History
 
+ * 3.1.3
+   * Fixed a crash when using `fromBuffer()` to read corrupt zip files that specify out of bounds file offsets. [issue #156](https://github.com/thejoshwolfe/yauzl/pull/156)
+   * Enahnced the test suite to run the error tests through `fromBuffer()` and `fromRandomAccessReader()` in addition to `open()`, which would have caught the above.
  * 3.1.2
    * Fixed handling non-64 bit entries (similar to the version 3.1.1 fix) that actually have exactly 0xffffffff values in the fields. This fixes erroneous "expected zip64 extended information extra field" errors. [issue #109](https://github.com/thejoshwolfe/yauzl/pull/109)
  * 3.1.1


### PR DESCRIPTION
Thanks @dominique-pfister for finding this.