### PR TITLE
using node:timers setImmediate

### DIFF
--- a/fd-slicer.js
+++ b/fd-slicer.js
@@ -7,6 +7,7 @@ var Writable = stream.Writable;
 var PassThrough = stream.PassThrough;
 var Pend = require('pend');
 var EventEmitter = require('events').EventEmitter;
+var setImmediate = require("timers").setImmediate;
 
 exports.createFromBuffer = createFromBuffer;
 exports.createFromFd = createFromFd;

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var EventEmitter = require("events").EventEmitter;
 var Transform = require("stream").Transform;
 var PassThrough = require("stream").PassThrough;
 var Writable = require("stream").Writable;
+var setImmediate = require("timers").setImmediate;
 
 exports.open = open;
 exports.fromFd = fromFd;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yauzl",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yauzl",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yauzl",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "yet another unzip library for node",
   "engines": {
     "node": ">=12"

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,8 @@ var child_process = require("child_process");
 var Readable = require("stream").Readable;
 var Writable = require("stream").Writable;
 
+globalThis.setImmediate = undefined; // simulate systems without setImmediate
+
 // This is a month before I made the example zip files and their content files,
 // so this timestamp will be earlier than all the ones stored in these test zip files unless otherwise noted.
 var earliestTimestamp = new Date(2014, 7, 18, 0, 0, 0, 0);


### PR DESCRIPTION
instead of relying on the global provided one as is deprecated in some systems

`setImmediate` has been [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate) in the WebAPI so is not present in some systems (jest / mocha to name a few)

This PR rely on using the provided node:timers setImmediate (which is provided since [node v0.9](https://nodejs.org/api/timers.html#setimmediatecallback-args:~:text=v0.9.1-,Added%20in%3A%20v0.9.1,-callback%20%3CFunction%3E)) instead, so yauzl can be agnostic and won't require consumers to set a polyfill to be able to use the library.