### PR TITLE
fix: early-exit in node v26

### DIFF
--- a/fd-slicer.js
+++ b/fd-slicer.js
@@ -88,31 +88,32 @@ function ReadStream(context, options) {
   this.start = options.start || 0;
   this.endOffset = options.end;
   this.pos = this.start;
-  this.destroyed = false;
+  this._destroyed = false;
 }
 
 ReadStream.prototype._read = function(n) {
   var self = this;
-  if (self.destroyed) return;
+  if (self._destroyed) return;
 
   var toRead = Math.min(self._readableState.highWaterMark, n);
   if (self.endOffset != null) {
     toRead = Math.min(toRead, self.endOffset - self.pos);
   }
   if (toRead <= 0) {
-    self.destroyed = true;
+    self._destroyed = true;
     self.push(null);
     self.context.unref();
     return;
   }
   self.context.pend.go(function(cb) {
-    if (self.destroyed) return cb();
+    if (self._destroyed) return cb();
     var buffer = Buffer.allocUnsafe(toRead);
     fs.read(self.context.fd, buffer, 0, toRead, self.pos, function(err, bytesRead) {
+      if (self._destroyed) return cb();
       if (err) {
         self.destroy(err);
       } else if (bytesRead === 0) {
-        self.destroyed = true;
+        self._destroyed = true;
         self.push(null);
         self.context.unref();
       } else {
@@ -125,11 +126,18 @@ ReadStream.prototype._read = function(n) {
 };
 
 ReadStream.prototype.destroy = function(err) {
-  if (this.destroyed) return;
-  err = err || new Error("stream destroyed");
-  this.destroyed = true;
-  this.emit('error', err);
-  this.context.unref();
+  if (err == null && !this.readableEnded) {
+    err = new Error("stream _destroyed");
+  }
+  return Readable.prototype.destroy.call(this, err);
+};
+
+ReadStream.prototype._destroy = function(err, cb) {
+  if (!this._destroyed) {
+    this._destroyed = true;
+    this.context.unref();
+  }
+  cb(err);
 };
 
 util.inherits(WriteStream, Writable);
@@ -144,14 +152,14 @@ function WriteStream(context, options) {
   this.endOffset = (options.end == null) ? Infinity : +options.end;
   this.bytesWritten = 0;
   this.pos = this.start;
-  this.destroyed = false;
+  this._destroyed = false;
 
   this.on('finish', this.destroy.bind(this));
 }
 
 WriteStream.prototype._write = function(buffer, encoding, callback) {
   var self = this;
-  if (self.destroyed) return;
+  if (self._destroyed) return;
 
   if (self.pos + buffer.length > self.endOffset) {
     var err = new Error("maximum file length exceeded");
@@ -161,7 +169,7 @@ WriteStream.prototype._write = function(buffer, encoding, callback) {
     return;
   }
   self.context.pend.go(function(cb) {
-    if (self.destroyed) return cb();
+    if (self._destroyed) return cb();
     fs.write(self.context.fd, buffer, 0, buffer.length, self.pos, function(err, bytes) {
       if (err) {
         self.destroy();
@@ -178,10 +186,12 @@ WriteStream.prototype._write = function(buffer, encoding, callback) {
   });
 };
 
-WriteStream.prototype.destroy = function() {
-  if (this.destroyed) return;
-  this.destroyed = true;
-  this.context.unref();
+WriteStream.prototype._destroy = function(err, cb) {
+  if (!this._destroyed) {
+    this._destroyed = true;
+    this.context.unref();
+  }
+  cb(err);
 };
 
 util.inherits(BufferSlicer, EventEmitter);
@@ -231,7 +241,7 @@ BufferSlicer.prototype.write = function(buffer, offset, length, position, callba
 BufferSlicer.prototype.createReadStream = function(options) {
   options = options || {};
   var readStream = new PassThrough(options);
-  readStream.destroyed = false;
+  readStream._destroyed = false;
   readStream.start = options.start || 0;
   readStream.endOffset = options.end;
   // by the time this function returns, we'll be done.
@@ -254,8 +264,9 @@ BufferSlicer.prototype.createReadStream = function(options) {
   }
 
   readStream.end();
-  readStream.destroy = function() {
-    readStream.destroyed = true;
+  readStream._destroy = function(err, cb) {
+    readStream._destroyed = true;
+    PassThrough.prototype._destroy.call(readStream, err, cb);
   };
   return readStream;
 };
@@ -268,15 +279,15 @@ BufferSlicer.prototype.createWriteStream = function(options) {
   writeStream.endOffset = (options.end == null) ? this.buffer.length : +options.end;
   writeStream.bytesWritten = 0;
   writeStream.pos = writeStream.start;
-  writeStream.destroyed = false;
+  writeStream._destroyed = false;
   writeStream._write = function(buffer, encoding, callback) {
-    if (writeStream.destroyed) return;
+    if (writeStream._destroyed) return;
 
     var end = writeStream.pos + buffer.length;
     if (end > writeStream.endOffset) {
       var err = new Error("maximum file length exceeded");
       err.code = 'ETOOBIG';
-      writeStream.destroyed = true;
+      writeStream._destroyed = true;
       callback(err);
       return;
     }
@@ -287,8 +298,9 @@ BufferSlicer.prototype.createWriteStream = function(options) {
     writeStream.emit('progress');
     callback();
   };
-  writeStream.destroy = function() {
-    writeStream.destroyed = true;
+  writeStream._destroy = function(err, cb) {
+    writeStream._destroyed = true;
+    cb(err);
   };
   return writeStream;
 };

--- a/test/test.js
+++ b/test/test.js
@@ -341,6 +341,38 @@ pend.go(function(cb) {
   });
 });
 
+// openReadStream async iteration
+pend.go(function(cb) {
+  var prefix = "openReadStream async iteration: ";
+  yauzl.open(path.join(__dirname, "success/cygwin-info-zip.zip"), {lazyEntries: true}, function(err, zipfile) {
+    if (err) throw err;
+    zipfile.on("error", function(err) {
+      throw err;
+    });
+    zipfile.once("close", function() {
+      console.log(prefix + "pass");
+      cb();
+    });
+    zipfile.readEntry();
+    zipfile.once("entry", function(entry) {
+      if (entry.compressionMethod !== 0) throw new Error(prefix + "expected stored entry");
+      zipfile.openReadStream(entry, function(err, readStream) {
+        if (err) throw err;
+        (async function() {
+          var bytesSeen = 0;
+          for await (var chunk of readStream) {
+            bytesSeen += chunk.length;
+          }
+          if (bytesSeen !== entry.uncompressedSize) throw new Error(prefix + "expected " + entry.uncompressedSize + " bytes; got " + bytesSeen);
+          zipfile.close();
+        })().catch(function(err) {
+          throw err;
+        });
+      });
+    });
+  });
+});
+
 // abort open read stream
 pend.go(function(cb) {
   var prefix = "abort open read stream: ";


### PR DESCRIPTION
`_read()` sets `_destroyed = true` before `push(null)`. After eof, node’s Readable lifecycle expects native `destroy()` to run so it can emit close and let async iterators finish. But fd-slicer’s custom `destroy()` sees `_destroyed` is already true and returns early, so `close` is never emitted and async iteration hangs until the process exits.